### PR TITLE
Explicitly AWS profile to auth gulp-s3-upload

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -90,6 +90,8 @@ function s3Upload(cacheControl, keyPrefix) {
         'ACL': 'public-read',
         'CacheControl': cacheControl,
         'keyTransform': fn => `${keyPrefix}/${fn}`
+    }, {
+      credentials: new AWS.SharedIniFileCredentials({profile: "interactives"})
     });
 }
 


### PR DESCRIPTION
I think this will switch the template to explicitly use an AWS profile.

This means instead of using "whatever AWS finds by default" (typically permanent credentials, possibly a profile if there are magic ENV vars in place) it'll only use the `interactives` profile. In our normal workflow this will be populated by Janus credentials.
If this seems too harsh a change, it could use a `CredentialProviderChain` that includes the default provider as a fallback to this profile. Sadly, that would hide problems with the temporary credentials so I'm not sure I can recommend that approach.

I've not tested this, so maybe I can go through it with someone that's working on an interactive based on this template? @wpf500 @katebee 