### PR TITLE
Update modules rules in gulpfile.babel.js to handle files with .mjs suffix

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -84,6 +84,10 @@ function buildJS(filename) {
                         {
                             test: /\.html$/,
                             use: 'raw-loader'
+                        },
+                        {
+                            test: /\.mjs$/,
+                            type: "javascript/auto",
                         }
                     ]
                 },


### PR DESCRIPTION
Update modules rules in gulpfile.babel.js to allow files with .mjs suffix to to be handled appropriately